### PR TITLE
feat: Upgrade Nu version to 0.99

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,12 +795,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -1067,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0b87c36d5d922b43679ca21416fc136d246a95965a177b9ab98fe1efa77512"
+checksum = "27055f050baefe46ec1ee7311c0cba27ec8700e18c6ab00f68a745f957da9f3f"
 dependencies = [
  "itertools 0.13.0",
  "nu-engine",
@@ -1081,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e617a828111a2fbd486698dab3ffa3894a52d6c77805f86babd5527ecb002ec3"
+checksum = "c4b4a5727c9696701727191f94f36804c82e182a2b1da1c97335672c9677c427"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -1094,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.98.0"
+version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2619f3ae9a21794cf4c49c2962c3e5274764d87a3e0d97587283796ae4b99a"
+checksum = "0a025752d8cae2f96a9215b34187f4cbbe96d5df0511575fbbdb8882700877c8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1107,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fab89403670cb3048f531ff8ac8d9cdfd9ac72862f9031194756d82729f9d8e"
+checksum = "ebb70da462cbfe52635826d2c3e73c9d381e181f39e3e19887b57252bd92d7b1"
 dependencies = [
  "log",
  "nu-glob",
@@ -1121,15 +1127,15 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.98.0"
+version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2367837197545cca98329358342d08498a5cfc0911d446debb35e3bbc5b44a"
+checksum = "57a0721c0947c445866aa34a430dd846c10b7eb34f61a390b15897e833cf0655"
 
 [[package]]
 name = "nu-json"
-version = "0.98.0"
+version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b4fc5ac76f928f8fcb04846c4c0662507cd09c173d7766cda53f4dc3c2b32"
+checksum = "e3df53c20ec0ce366a7fbda4a6bfea70a72c8630a26afa9f0e4b0f927163b975"
 dependencies = [
  "linked-hash-map",
  "num-traits",
@@ -1139,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fa0707d58bacb43227e3c1a48bb6c6cceb9c6e11ca70ebe5b307a4f66dd7cc"
+checksum = "cd6b22646adbb8fff8949935ce86240a149f28d7f094d23f981145b404e25e94"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1156,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.98.0"
+version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fdfbc5a5f6f86b21b3035dc8043b09543ecf4d505010df99b35231abeb9d44"
+checksum = "de17919a6834e6b773256a2f29632571473ee3c83a1530f6385c3a80d13b0564"
 dependencies = [
  "dirs",
  "omnipath",
@@ -1167,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17233bbf5c41a478e35b8800c88cf9a53b9633346da138430a35ec8344ce7a6"
+checksum = "f9f79431b72f4f04016d8d86ff01beb61c02163a56d01eb388d44beeacba3435"
 dependencies = [
  "log",
  "nix 0.29.0",
@@ -1183,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738b28a0c4ff5a24666b67f2b5c1bbc6fdc5007149a19a1f490b4827b8fa67ae"
+checksum = "ad9bd9ea5cda3eec3b0482add15b0437757b0360a956d111ed5f5b564800bea5"
 dependencies = [
  "interprocess",
  "log",
@@ -1199,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9aebd8b8ddb674b35f3cf17846b29b5ed90bc0448a87a8e865910b4aa3ce74"
+checksum = "441283b2de93284d66332523451ad1baca257accb18bffb2499fcfa555199eb4"
 dependencies = [
  "log",
  "nu-engine",
@@ -1216,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8971280787b5f77749c4738cfaf71b429f7b44715ebc88d22a0bb133ee61f41b"
+checksum = "34524d87a48c376d29a93d1c96d877aeb9ddac4fb5037a402462159e792f689b"
 dependencies = [
  "nu-protocol",
  "nu-utils",
@@ -1230,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c671898f5658e3df4e5aba9541ebc18d3de29384b5227777e0e548eda62728"
+checksum = "7efbd113106b1a916dba2e522c9b35f4bb9044361cc8404cbbc5c7e4488d895a"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -1248,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.98.0"
+version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d2b192c6f44b22bf6fadebe8cb4c0450c5f3a1ef0760b10a8a34d86a408d37"
+checksum = "9fdd6c9896962f3d36601668e590ccc078bfb34ea97ee3c0e3b1261d2f4dc229"
 dependencies = [
  "brotli",
  "byte-unit",
@@ -1261,7 +1267,7 @@ dependencies = [
  "dirs-sys",
  "fancy-regex",
  "heck",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "log",
  "lru",
  "miette",
@@ -1281,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.98.0"
+version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08076dc19b3b6b51721e70296f6ee50af46badad86fdbb3149dd39660140115c"
+checksum = "2b4ff5f7b8a9a7f120d49005afdb2bb2ef3261862ca1de198ad2842896085f1b"
 dependencies = [
  "chrono",
  "itertools 0.13.0",
@@ -1301,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.98.0"
+version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d17bc14c181cb42fadbacfecbd2a4d68912dd24e49278e428e585b7b4ec7f3"
+checksum = "15c781ee0f64b928c2ddc6c371a9892337874959c4c7df914687273469152d63"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1369,9 +1375,9 @@ checksum = "80adb31078122c880307e9cdfd4e3361e6545c319f9b9dcafcb03acd3b51a575"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "option-ext"
@@ -1785,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe0bac8a8752586a618a1c80d01d8ca5d40fce4f6077fbc851e48dcbdb90df"
+checksum = "2311e39772c00391875f40e34d43efef247b23930143a70ca5fbec9505937420"
 dependencies = [
  "const_format",
  "is_debug",
@@ -2040,7 +2046,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ license = "MIT"
 # for local development, you can use a path dependency
 # nu-plugin = { path = "../nushell/crates/nu-plugin" }
 # nu-protocol = { path = "../nushell/crates/nu-protocol", features = ["plugin"] }
-nu-plugin = "0.98"
-nu-protocol = { version = "0.98", features = ["plugin"] }
-#nu-table = "0.98"
-nu-color-config = "0.98"
+nu-plugin = "0.99"
+nu-protocol = { version = "0.99", features = ["plugin"] }
+#nu-table = "0.99"
+nu-color-config = "0.99"
 skim = { package = "two_percent", version = "0.12", no_default_features = true }
 
 [dev-dependencies]
 # nu-plugin-test-support = { path = "../nushell/crates/nu-plugin-test-support" }
-nu-plugin-test-support = { version = "0.98" }
+nu-plugin-test-support = { version = "0.99" }

--- a/src/cli_arguments.rs
+++ b/src/cli_arguments.rs
@@ -129,9 +129,9 @@ impl CliArguments {
                     "skim_v1" => Ok(FuzzyAlgorithm::SkimV1),
                     "skim_v2" => Ok(FuzzyAlgorithm::SkimV2),
                     "clangd" => Ok(FuzzyAlgorithm::Clangd),
-                    _ => Err(ShellError::UnsupportedConfigValue {
-                        expected: "skim_v1|skim_v2|clangd".to_owned(),
-                        value: flag.to_owned(),
+                    _ => Err(ShellError::InvalidValue {
+                        valid: "[skim_v1|skim_v2|clangd]".to_owned(),
+                        actual: flag.to_owned(),
                         span: call
                             .get_flag_value("algo")
                             .expect("we already know the flag exists")
@@ -147,9 +147,9 @@ impl CliArguments {
                     "smart" => Ok(CaseMatching::Smart),
                     "ignore" => Ok(CaseMatching::Ignore),
                     "respect" => Ok(CaseMatching::Respect),
-                    _ => Err(ShellError::UnsupportedConfigValue {
-                        expected: "[smart|ignore|respect]".to_owned(),
-                        value: flag.to_owned(),
+                    _ => Err(ShellError::InvalidValue {
+                        valid: "[smart|ignore|respect]".to_owned(),
+                        actual: flag.to_owned(),
                         span: call
                             .get_flag_value("case")
                             .expect("we already know the flag exists")


### PR DESCRIPTION
The flag parsing was using `ShellError::UnsupportedConfigValue`, which was removed in nu-protocol 0.99. I've changed those instances to `ShellError::InvalidValue`, which is more correct as the flags are not config values.