### PR TITLE
command-mode displays nothing in stream mode (issue #64)

### DIFF
--- a/src/command_collector.rs
+++ b/src/command_collector.rs
@@ -60,9 +60,7 @@ impl CommandCollector for NuCommandCollector {
                 }
                 Ok(stream) => {
                     for value in stream {
-                        if rx_interrupt.try_recv().is_ok() {
-                            break;
-                        }
+
                         let send_result =
                             tx.send(vec![Arc::new(NuItem::new(context.clone(), value))]);
                         if send_result.is_err() {


### PR DESCRIPTION
Tentatively removing the rx_interrupt check in the Ok(Stream) section of the command collector source file. 

Before this change, the following command returns nothing in the UI. 

ls | get name |sk -i -c {|query|  ls | where name =~ $query |get name}

After the change, the command correctly streams the ouput of the ls to the UI.

It would seem the rx_interrupt check never lets the collector finish.
